### PR TITLE
[fix]: opts, update repository files

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,63 @@
+name: GitHub Copilot Coding Agent Setup Guide
+
+# This file is used by GitHub Copilot Coding Agent to set up the environment
+# See: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/customizing-the-development-environment-for-copilot-coding-agent
+
+on:
+  # This workflow is intended to be used by GitHub Copilot
+  workflow_dispatch:
+
+# Explicitly define minimum required permissions
+permissions:
+  contents: read
+
+jobs:
+  setup-guide:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Prerequisites
+        run: |
+          echo "::setup::Install ZSH"
+          sudo apt-get update
+          sudo apt-get install -y zsh
+
+      - name: Setup diff-so-fancy
+        run: |
+          echo "::setup::Install diff-so-fancy"
+          git clone https://github.com/so-fancy/diff-so-fancy.git /tmp/diff-so-fancy
+          sudo cp /tmp/diff-so-fancy/diff-so-fancy /usr/local/bin/
+          sudo chmod +x /usr/local/bin/diff-so-fancy
+
+      - name: Test Environment
+        run: |
+          echo "::test::Test diff-so-fancy installation"
+          diff-so-fancy --version
+
+      - name: Setup Instructions
+        run: |
+          echo "::info::Plugin Usage"
+          echo "This zsh plugin provides:"
+          echo "- git dsf: A Git subcommand to run Git diffs through diff-so-fancy"
+          echo "- fancy-diff: A helper to compare two files with diff-so-fancy"
+
+          echo "::info::Environment Variables"
+          echo "You can customize the output by setting these environment variables:"
+          echo "- FANCY_DIFF_LESS_OPTS: Options for less when using fancy-diff"
+          echo "- GIT_DSF_LESS_OPTS: Options for less when using git dsf"
+
+          echo "::info::Testing the plugin"
+          echo "To test the plugin after changes:"
+          echo "1. Run 'zsh' to start a new zsh session"
+          echo "2. Source the plugin: source zsh-diff-so-fancy.plugin.zsh"
+          echo "3. Create two test files with different content"
+          echo "4. Run: fancy-diff file1 file2"
+          echo "5. Run: git dsf (in a git repository)"
+
+      - name: Development Workflow
+        run: |
+          echo "::info::Development Workflow"
+          echo "1. Make changes to zsh-diff-so-fancy.plugin.zsh or scripts in bin/"
+          echo "2. Ensure scripts have proper error handling and comments"
+          echo "3. Test changes in a zsh shell"
+          echo "4. Update documentation in docs/README.md if needed"
+          echo "5. Run trunk check before committing: trunk check"

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,8 +2,7 @@
 *logs
 *actions
 *notifications
-tools
-tools.log
+*tools
 plugins
 user_trunk.yaml
 user.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,20 +4,20 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.0
+      ref: v1.7.1
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - checkov@3.2.435
-    - trufflehog@3.88.35
+    - checkov@3.2.451
+    - trufflehog@3.90.0
     - yamllint@1.37.1
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - gitleaks@8.26.0
+    - gitleaks@8.27.2
     - actionlint@1.7.7
     - markdownlint@0.45.0
     - git-diff-check
-    - prettier@3.5.3
+    - prettier@3.6.2
 runtimes:
   enabled:
     - python@3.10.8

--- a/bin/fancy-diff
+++ b/bin/fancy-diff
@@ -22,6 +22,10 @@ ff() {
   # Use FANCY_DIFF_LESS_OPTS if set, otherwise fallback to a default.
   # The plugin typically sets a default for FANCY_DIFF_LESS_OPTS.
   local less_opts="${FANCY_DIFF_LESS_OPTS:---tabs=4 -FRXSi}"
+
+  # Run diff with unified output (-u), colorized, and pipe through diff-so-fancy
+  # The --patch flag preserves the original diff format in the output
+  # This is useful for interoperability with tools that parse diff output
   command diff -u "$1" "$2" --color=always | diff-so-fancy --patch | less "${less_opts}"
 }
 

--- a/bin/git-dsf
+++ b/bin/git-dsf
@@ -6,7 +6,11 @@ f() {
   # The plugin zsh-diff-so-fancy.plugin.zsh typically sets a default for GIT_DSF_LESS_OPTS.
   local less_opts="${GIT_DSF_LESS_OPTS:---tabs=4 -FRXSi}"
 
+  # Handle Git prefix directory if set (for submodules and special Git contexts)
   [[ -z "${GIT_PREFIX}" ]] || builtin cd -q "${GIT_PREFIX}" && \
+    # Run git diff with color, pipe through diff-so-fancy
+    # The --patch flag preserves the original diff format in the output
+    # This is useful for interoperability with tools that parse git diff output
     command git diff --color=always "$@" | diff-so-fancy --patch | less "${less_opts}"
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,20 @@ A simple plugin integrating [so-fancy/diff-so-fancy](https://github.com/so-fancy
    - `git dsf <files>` to see a diff rendered by diff-so-fancy
    - `fancy-diff <file1> <file2>` to compare two files with diff-so-fancy
 
+## Customization
+
+You can customize the `less` options by setting these environment variables in your `.zshrc` before loading the plugin:
+
+```shell
+# Customize less options for fancy-diff
+export FANCY_DIFF_LESS_OPTS="--tabs=2 -RFX"
+
+# Customize less options for git dsf
+export GIT_DSF_LESS_OPTS="--tabs=2 -FRXS"
+```
+
+The default is `--tabs=4 -FRXSi` for both commands if not specified.
+
 ## Manual Configuration
 
 ```shell
@@ -58,6 +72,12 @@ git config --global interactive.diffFilter "diff-so-fancy --patch"
   Use Unicode line-drawing characters for file headers (disable if your terminal cannot display them).
 - **rulerWidth** (int, default: full width)
   Set a fixed width for the file header separator.
+
+### Plugin Details
+
+- Both `fancy-diff` and `git-dsf` use the `--patch` flag with `diff-so-fancy` to preserve the original diff format in the output, which is useful for interoperability with tools that parse diff output.
+- The plugin follows the [Zsh Plugin Standard](https://wiki.zshell.dev/community/zsh_plugin_standard) and provides an unload function for plugin managers that support unloading.
+- The plugin checks if `diff-so-fancy` is installed and provides a helpful warning if it's not found.
 
 ### Installation with [Zi](https://github.com/z-shell/zi)
 

--- a/zsh-diff-so-fancy.plugin.zsh
+++ b/zsh-diff-so-fancy.plugin.zsh
@@ -47,7 +47,7 @@ zsh_diff_so_fancy_plugin_unload() {
 
   # Unset the global variables if they were set by this plugin
   # Note: We avoid unsetting if they might have been set by the user
-  unset -f "FANCY_DIFF_LESS_OPTS" "GIT_DSF_LESS_OPTS" 2>/dev/null
+  unset FANCY_DIFF_LESS_OPTS GIT_DSF_LESS_OPTS 2>/dev/null
 
   # Clean up the function itself
   unfunction zsh_diff_so_fancy_plugin_unload


### PR DESCRIPTION
This pull request introduces a new GitHub Copilot Coding Agent setup guide, updates plugin configurations, and enhances the `diff-so-fancy` integration plugin. Key changes include the addition of a setup workflow, updates to Trunk plugin versions, improved customization options for `diff-so-fancy`, and better adherence to Zsh plugin standards.

### GitHub Copilot Setup Workflow:

* [`.github/workflows/copilot-setup-steps.yml`](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR1-R63): Added a workflow for setting up the environment, including installation steps for `zsh` and `diff-so-fancy`, testing instructions, and development workflows.

### Plugin Configuration Updates:

* [`.trunk/trunk.yaml`](diffhunk://#diff-45a5a35dd7ad9a52d0fd3540f6c0d16a763575de51cc9a0a6c6f6a9f1da62ecdL7-R20): Updated Trunk plugin versions, including `checkov`, `trufflehog`, `gitleaks`, and `prettier`, to their latest versions.
* [`.trunk/.gitignore`](diffhunk://#diff-66ab252224fe775ee73e386e622f9f3a40832c7cd0b9ff73fa524e744a83e236L5-R5): Adjusted the `.gitignore` file to ensure proper exclusion of `tools` and related logs.

### Enhancements to `diff-so-fancy` Plugin:

* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R31-R44): Added customization options for `less` commands via environment variables and clarified plugin details, such as interoperability and adherence to Zsh Plugin Standards. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R31-R44) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R76-R81)
* [`zsh-diff-so-fancy.plugin.zsh`](diffhunk://#diff-78d9503307f601a512de89a7f0db82e8fbc7675e0c5d79134330053068c6fab0R22-R33): Improved variable scoping using `typeset` to prevent namespace leakage and added cleanup logic for unloading the plugin, including unsetting global variables. [[1]](diffhunk://#diff-78d9503307f601a512de89a7f0db82e8fbc7675e0c5d79134330053068c6fab0R22-R33) [[2]](diffhunk://#diff-78d9503307f601a512de89a7f0db82e8fbc7675e0c5d79134330053068c6fab0R47-L43)